### PR TITLE
Fixed daemon issue on Python pre-3.3

### DIFF
--- a/gps3/agps3threaded.py
+++ b/gps3/agps3threaded.py
@@ -11,7 +11,6 @@ except ImportError:
     from . import agps3  # Python 2
 
 
-
 __author__ = 'Moe'
 __copyright__ = 'Copyright 2016  Moe'
 __license__ = 'MIT'
@@ -50,7 +49,12 @@ class AGPS3mechanism(object):
         """run thread with data
         """
         # self.stream_data() # Unless other changes are made this would limit to localhost only.
-        gps3_data_thread = Thread(target=self.unpack_data, args={usnap: usnap}, daemon=True)
+        try:
+            gps3_data_thread = Thread(target=self.unpack_data, args={usnap: usnap}, daemon=daemon)
+        except TypeError:
+            # threading.Thread() only accepts daemon argument in Python 3.3
+            gps3_data_thread = Thread(target=self.unpack_data, args={usnap: usnap})
+            gps3_data_thread.setDaemon(daemon)
         gps3_data_thread.start()
 
     def stop(self):
@@ -58,7 +62,7 @@ class AGPS3mechanism(object):
         """
         self.stream_data(enable=False)  # Close data stream, thread is on its own so far.
         print('Process stopped by user')
-        print('Good bye.')[  # You haven't gone anywhere, re-start it all with 'self..stream_data()'
+        print('Good bye.')  # You haven't gone anywhere, re-start it all with 'self..stream_data()'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Although Python 2.7 documentation claims to have the daemon keyword in threading.Thread (supposedly introduced in 2.6) it is still missing:

```
$ python
Python 2.7.5 (default, Mar  9 2014, 22:15:05) 
[GCC 4.2.1 Compatible Apple LLVM 5.0 (clang-500.0.68)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from threading import Thread
>>> Thread(daemon=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __init__() got an unexpected keyword argument 'daemon'
>>> 
```
It works in Python3:

```
$ python3
Python 3.5.2 (default, Jun 29 2016, 13:42:46) 
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from threading import Thread
>>> Thread(daemon=True)
<Thread(Thread-1, initial daemon)>
>>> 
```